### PR TITLE
Refactor/#109 : 회원가입 로직 수정

### DIFF
--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Get, Param, Post, Res, UploadedFiles, UseGuards, UseInterceptors } from '@nestjs/common';
-import { FilesInterceptor } from '@nestjs/platform-express';
+import { Body, Controller, Get, Param, Post, Res, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { Response } from 'express';
 import { AuthService } from 'src/auth/auth.service';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
@@ -17,13 +17,11 @@ export class UserController {
     ){}
 
     @Post('/signup')
-    @UseInterceptors(FilesInterceptor('files'))
-    async signup(@Body() createUserDto: CreateUserDto, @Res() res: Response, @UploadedFiles() files: Array<Express.Multer.File>){
-        const { access, refresh, result } = await this.userService.createUser(createUserDto);
-        console.log(files);
-        await this.userService.saveProfilePhoto(result.userIdx, files);
-        res.cookie('Authentication', access.accessToken, access.accessOption);
-        res.cookie('Refresh', refresh.refreshToken, refresh.refreshOption);
+    @UseInterceptors(FileInterceptor('photo'))
+    async signup(@Body() createUserDto: CreateUserDto, @Res() res: Response, @UploadedFile() photo: Express.Multer.File){
+        const result = await this.userService.createUser(createUserDto);
+        console.log(photo);
+        await this.userService.saveProfilePhoto(result.userIdx, photo);
         res.send(result);
     }
 


### PR DESCRIPTION
[ 진행 사항 ]
- [x] 회원가입 시 토큰 발급 취소
- [x] 회원가입 프로필 사진 업로드 로직 변경

[ 세부 사항 ]
- 회원가입 성공 시 status 값은 2, msg는 "회원가입을 완료했습니다"를 담은 객체가 반환된다.
- 기존 회원가입 시 multipart/form-data를 보낼 때 files의 key 값으로 보냈는데 photo로 key 값을 변경했다. 